### PR TITLE
Fix yarn build error

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,22 +1,22 @@
 import defaults from 'lodash/defaults';
 
-import React, {ChangeEvent, PureComponent} from 'react';
-import {InlineFormLabel, LegacyForms} from '@grafana/ui';
-import {QueryEditorProps, SelectableValue} from '@grafana/data';
-import {DataSource} from './DataSource';
-import {defaultQuery, MyDataSourceOptions, EventsQuery} from './types';
+import React, { ChangeEvent, PureComponent } from 'react';
+import { InlineFormLabel, LegacyForms } from '@grafana/ui';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { DataSource } from './DataSource';
+import { defaultQuery, MyDataSourceOptions, EventsQuery } from './types';
 
-const {Input, Select} = LegacyForms;
+const { Input, Select } = LegacyForms;
 
 type Props = QueryEditorProps<DataSource, EventsQuery, MyDataSourceOptions>;
 
 const kindOptions: Array<SelectableValue<string>> = [
-  {value: 'PodChaos', label: 'pod chaos'},
-  {value: 'NetworkChaos', label: 'network chaos'},
-  {value: 'IOChaos', label: 'io chaos'},
-  {value: 'TimeChaos', label: 'time chaos'},
-  {value: 'KernelChaos', label: 'kernel chaos'},
-  {value: 'StressChaos', label: 'stress chaos'},
+  { value: 'PodChaos', label: 'pod chaos' },
+  { value: 'NetworkChaos', label: 'network chaos' },
+  { value: 'IOChaos', label: 'io chaos' },
+  { value: 'TimeChaos', label: 'time chaos' },
+  { value: 'KernelChaos', label: 'kernel chaos' },
+  { value: 'StressChaos', label: 'stress chaos' },
 ];
 
 export class QueryEditor extends PureComponent<Props> {
@@ -41,13 +41,13 @@ export class QueryEditor extends PureComponent<Props> {
   };
 
   onRunQuery = () => {
-    const {query} = this;
+    const { query } = this;
     this.props.onChange(query);
     this.props.onRunQuery();
   };
 
   render() {
-    const {namespace, experiment} = this.query;
+    const { namespace, experiment } = this.query;
     const selectedKind = kindOptions.find(o => o.value === this.query.kind);
 
     return (


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fix some linting issues in master

``` bash
➜  chaos-mesh-datasource git:(master) ✗ yarn build
yarn run v1.22.4
$ grafana-toolkit plugin:build
✔ Preparing
⠙ Linting  
  
  
  /home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/src/QueryEditor.tsx
     3:16  error  Replace `ChangeEvent,·PureComponent` with `·ChangeEvent,·PureComponent·`                                          prettier/prettier
     4:9   error  Replace `InlineFormLabel,·LegacyForms` with `·InlineFormLabel,·LegacyForms·`                                      prettier/prettier
     5:9   error  Replace `QueryEditorProps,·SelectableValue` with `·QueryEditorProps,·SelectableValue·`                            prettier/prettier
     6:9   error  Replace `DataSource` with `·DataSource·`                                                                          prettier/prettier
     7:9   error  Replace `defaultQuery,·MyDataSourceOptions,·EventsQuery` with `·defaultQuery,·MyDataSourceOptions,·EventsQuery·`  prettier/prettier
     9:8   error  Replace `Input,·Select` with `·Input,·Select·`                                                                    prettier/prettier
    14:4   error  Replace `value:·'PodChaos',·label:·'pod·chaos'` with `·value:·'PodChaos',·label:·'pod·chaos'·`                    prettier/prettier
    15:4   error  Replace `value:·'NetworkChaos',·label:·'network·chaos'` with `·value:·'NetworkChaos',·label:·'network·chaos'·`    prettier/prettier
    16:4   error  Replace `value:·'IOChaos',·label:·'io·chaos'` with `·value:·'IOChaos',·label:·'io·chaos'·`                        prettier/prettier
    17:4   error  Replace `value:·'TimeChaos',·label:·'time·chaos'` with `·value:·'TimeChaos',·label:·'time·chaos'·`                prettier/prettier
    18:4   error  Replace `value:·'KernelChaos',·label:·'kernel·chaos'` with `·value:·'KernelChaos',·label:·'kernel·chaos'·`        prettier/prettier
    19:4   error  Replace `value:·'StressChaos',·label:·'stress·chaos'` with `·value:·'StressChaos',·label:·'stress·chaos'·`        prettier/prettier
    44:12  error  Replace `query` with `·query·`                                                                                    prettier/prettier
    50:12  error  Replace `namespace,·experiment` with `·namespace,·experiment·`                                                    prettier/prettier
  
  ✖ 14 problems (14 errors, 0 warnings)
    14 errors and 0 warnings potentially fixable with the `--fix` option.
  
  
  
  Trace: Error: 14 linting errors found in 6 files
      at /home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/src/cli/tasks/plugin.build.js:117:31
      at step (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:136:27)
      at Object.next (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:117:57)
      at fulfilled (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:107:62)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at /home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/src/cli/utils/useSpinner.js:24:29
      at step (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:136:27)
      at Object.throw (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:117:57)
      at rejected (/home/yeya24/hub/grafana-plugins/chaos-mesh-datasource/node_modules/@grafana/toolkit/node_modules/tslib/tslib.js:108:69)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
✖ 14 linting errors found in 6 files
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```